### PR TITLE
fix: pass auth credentials to MongoDB healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,11 @@ services:
     volumes:
       - mongo-data:/data/db
     healthcheck:
-      test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')", "--quiet"]
+      test: ["CMD-SHELL", "mongosh --username $$MONGO_INITDB_ROOT_USERNAME --password $$MONGO_INITDB_ROOT_PASSWORD --authenticationDatabase admin --eval \"db.adminCommand('ping')\" --quiet"]
       interval: 30s
       timeout: 10s
       retries: 5
-      start_period: 30s
+      start_period: 40s
 
   backend:
     build:


### PR DESCRIPTION
Healthcheck was failing because mongosh ran without credentials, but MongoDB has auth enabled via MONGO_INITDB_ROOT_USERNAME/PASSWORD.